### PR TITLE
シバンの変更とシンボリックリンクの削除

### DIFF
--- a/bin/stow_reset
+++ b/bin/stow_reset
@@ -98,7 +98,7 @@ fi
 
 # Remove files/directories
 while read f;do
-  if [ -f "$targetdir"/"$f" ];then
+  if [ -f "$targetdir"/"$f" -o -L "$targetdir"/"$f" ];then
     echo rm -f "$targetdir"/"$f"
     rm -f "$targetdir"/"$f"
   elif [ -d "$f" ];then


### PR DESCRIPTION
bashが`/bin/bash`になくても動くようにしました。
また、先に実体が削除された場合に`-f "$targetdir"/"$f"`がfalseを返して、シンボリックリンクが削除されなかったため修正をしました
